### PR TITLE
fix loss function size mismatch

### DIFF
--- a/models/pate_gan.py
+++ b/models/pate_gan.py
@@ -90,7 +90,9 @@ class PATE_GAN:
                     optimizer_td[i].zero_grad()
                     label = torch.full((inputs.size()[0],), real_label).cuda()
                     output = self.teacher_disc[i].forward(torch.cat([inputs, categories.unsqueeze(1).double()], dim=1))
-                    err_d_real = criterion(output, label.double())
+                    label = label.unsqueeze(1)
+                    label = label.double()
+                    err_d_real = criterion(output, label)
                     err_d_real.backward()
 
                     # train with fake
@@ -147,8 +149,9 @@ class PATE_GAN:
             else:
                 fake = self.generator(z.double())
                 output = self.student_disc.forward(fake)
-
-            err_g = criterion(output, label.double())
+            label = label.unsqueeze(1)
+            label = label.double()
+            err_g = criterion(output, label)
             err_g.backward()
             optimizer_g.step()
 


### PR DESCRIPTION
When I tried to reproduce the Diabetes results using pate-gan with the command below, I got an torch size mismatch error. After searching online,  I found that it's caused by the loss function. Here's the StackOverflow [issue](https://stackoverflow.com/questions/65537991/valueerror-target-size-torch-size1000-must-be-the-same-as-input-size-tor)

So I added some fixes before passing the label (target) to criterion in pate-gan train function. Then the training worked.

`!python evaluate.py --target-variable='status' \
--train-data-path=./data/processed_train.csv \
--test-data-path=./data/processed_test.csv --normalize-data pate-gan \
--enable-privacy --target-epsilon=8 --target-delta=1e-5 --save-synthetic --lap-scale=1e-4 `

`Traceback (most recent call last):
  File "evaluate.py", line 144, in <module>
    lap_scale=opt.lap_scale, class_ratios=class_ratios, lr=1e-4))
  File "/content/private-data-generation/models/pate_gan.py", line 93, in train
    err_d_real = criterion(output, label.double())
  File "/usr/local/lib/python3.7/dist-packages/torch/nn/modules/module.py", line 889, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/torch/nn/modules/loss.py", line 613, in forward
    return F.binary_cross_entropy(input, target, weight=self.weight, reduction=self.reduction)
  File "/usr/local/lib/python3.7/dist-packages/torch/nn/functional.py", line 2755, in binary_cross_entropy
    "Please ensure they have the same size.".format(target.size(), input.size())
ValueError: Using a target size (torch.Size([64])) that is different to the input size (torch.Size([64, 1])) is deprecated. Please ensure they have the same size.`

